### PR TITLE
SSSB: Style Fixes

### DIFF
--- a/mods/seasonal/abilities.js
+++ b/mods/seasonal/abilities.js
@@ -37,7 +37,7 @@ exports.BattleAbilities = {
 	interdimensional:{
 		shortDesc: "On switch-in, summons Gravity.",
 		onStart: function () {
-			this.addPseudoWeather('Gravity');
+			this.addPseudoWeather('gravity');
 		},
 	},
 	// Teremiare

--- a/mods/seasonal/moves.js
+++ b/mods/seasonal/moves.js
@@ -42,7 +42,7 @@ exports.BattleMovedex = {
 		id: "pilfer",
 		isNonstandard: true,
 		name: "Pilfer",
-		pp: 8,
+		pp: 5,
 		priority: 3, //nerf if it's to broken
 		flags: {protect: 1, authentic: 1},
 		onTryHit: function (target, pokemon) {
@@ -290,11 +290,12 @@ exports.BattleMovedex = {
  		accuracy: true,
  		basePower: 180,
  		category: "Physical",
- 		shortDesc: "No additional effect.",
+ 		shortDesc: "Raises Atk by, Def and SpD by 1.",
  		id: "boi",
  		isNonstandard: true,
  		name: "B O I",
  		pp: 1,
+		noPPBoosts: true,
  		priority: 0,
 		isZ: 'imasiumz',
 		flags: {protect: 1, mirror: 1},
@@ -496,6 +497,7 @@ exports.BattleMovedex = {
 		isViable: true,
 		name: "dragonswrath",
 		pp: 17,
+		noPPBoosts: true,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
 		onEffectiveness: function (typeMod, type) {

--- a/mods/seasonal/random-teams.js
+++ b/mods/seasonal/random-teams.js
@@ -62,7 +62,7 @@ class RandomStaffBrosTeams extends RandomTeams {
 				evs: {hp:4, atk:252, spe:252}, nature: 'Jolly',
 			},
 			'Joim': {
-				species: 'Zapdos', ability:'Tinted Lens', item: 'Life Orb', gender: 'N',
+				species: 'Zapdos', ability: 'Tinted Lens', item: 'Life Orb', gender: 'N',
 				moves: ['Roost', 'Hurricane', ['Thunderbolt', 'Quiver Dance'][this.random(2)]],
 				signatureMove: 'Retirement',
 				evs: {hp: 4, spa: 252, spe: 252}, nature: 'Modest', //ask nature
@@ -125,7 +125,7 @@ class RandomStaffBrosTeams extends RandomTeams {
 			'Trickster': {
 				species: 'Hoopa', ability: 'Shadow Shield', item: 'Figy Berry',
 				gender: 'M',
-				moves: ['Inferno', 'Zap cannon', ['Dynamic Punch', 'Grass Whistle'][this.random(2)]],
+				moves: ['Inferno', 'Zap Cannon', ['Dynamic Punch', 'Grass Whistle'][this.random(2)]],
 				signatureMove: 'Event Horizon',
 				evs: {hp: 252, atk: 4, spa: 252}, ivs: {spe: 0}, nature: 'Quiet', 
 			},


### PR DESCRIPTION
If you choose a random PP (not ending in 5 or 0, PS attempts to PP up said move, so using ``noPPBoosts: true,`` makes it stay without PP Ups.