### PR TITLE
Update inactive

### DIFF
--- a/data/mods/ssb/items.js
+++ b/data/mods/ssb/items.js
@@ -38,6 +38,18 @@ let BattleItems = {
 		gen: 7,
 		desc: "If held by a Golem with Rock Slide, it can use Rickrollout.",
 	},
+	// inactive
+	dusknoiriumz: {
+		id: "dusknoiriumz",
+		name: "Dusknoirium Z",
+		isNonstandard: "Custom",
+		onTakeItem: false,
+		zMove: "Petrifying Gaze",
+		zMoveFrom: "Mean Look",
+		zMoveUser: ["Dusknoir"],
+		gen: 7,
+		desc: "If held by a Dusknoir with Mean Look, it can use Petrifying Gaze.",
+	},
 	// Kris
 	thunderstone: {
 		inherit: true,

--- a/data/mods/ssb/moves.js
+++ b/data/mods/ssb/moves.js
@@ -2002,7 +2002,7 @@ let BattleMovedex = {
 		onPrepareHit(target, source) {
 			this.add('-anim', source, 'Heart Stamp', target);
 		},
-		flags: {protect: 1, mirror: 1}
+		flags: {protect: 1, mirror: 1},
 		secondaries: [
 			{
 				chance: 30,

--- a/data/mods/ssb/moves.js
+++ b/data/mods/ssb/moves.js
@@ -1965,9 +1965,9 @@ let BattleMovedex = {
 		id: "petrifyinggaze",
 		name: "Petrifying Gaze",
 		isNonstandard: "Custom",
-		pp: 10,
+		pp: 1,
 		priority: 0,
-		flags: {reflectable: 1, mirror: 1},
+		flags: {},
 		onTryMove() {
 			this.attrLastMove('[still]');
 		},

--- a/data/mods/ssb/moves.js
+++ b/data/mods/ssb/moves.js
@@ -1979,6 +1979,7 @@ let BattleMovedex = {
 			target.trySetStatus('par', source);
 			return target.addVolatile('trapped', source, move, 'trapper');
 		},
+		isZ: "dusknoiriumz",
 		secondary: null,
 		target: "normal",
 		type: "Ghost",
@@ -2001,7 +2002,7 @@ let BattleMovedex = {
 		onPrepareHit(target, source) {
 			this.add('-anim', source, 'Heart Stamp', target);
 		},
-		flags: {protect: 1, mirror: 1},
+		flags: {protect: 1, mirror: 1}
 		secondaries: [
 			{
 				chance: 30,

--- a/data/mods/ssb/random-teams.js
+++ b/data/mods/ssb/random-teams.js
@@ -332,9 +332,9 @@ class RandomStaffBrosTeams extends RandomTeams {
 				evs: {def: 4, spa: 252, spe: 252}, ivs: {atk: 0}, nature: 'Timid',
 			},
 			'inactive': {
-				species: 'Dusknoir', ability: 'Soul Eater', item: 'Life Orb', gender: '',
+				species: 'Dusknoir', ability: 'Soul Eater', item: 'Dusknoirium Z', gender: '',
 				moves: ['Earthquake', 'Shadow Force', 'Shadow Sneak'],
-				signatureMove: 'Petrifying Gaze',
+				signatureMove: 'Mean Look',
 				evs: {hp: 4, atk: 252, spe: 252}, nature: 'Jolly',
 			},
 			'irritated': {


### PR DESCRIPTION
inactive's signature move is now a Z-move.

* Updated moves.js to identify the move as such
* Updated items.js to create a custom z-crystal for the move
* Update random-teams.js to give inactive the z-crystal and Mean Look