### PR TITLE
Celine draft

### DIFF
--- a/data/mods/ssb/abilities.ts
+++ b/data/mods/ssb/abilities.ts
@@ -386,7 +386,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		},
 	},
 
-	// Celine 
+	// Celine
 	guardianarmor: {
 		desc: "Raises Defense and Special Defense by two stages upon switch in.",
 		shortDesc: "+2 Def and SpD on switch in.",

--- a/data/mods/ssb/abilities.ts
+++ b/data/mods/ssb/abilities.ts
@@ -386,6 +386,16 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		},
 	},
 
+	// Celine 
+	guardianarmor: {
+		desc: "Raises Defense and Special Defense by two stages upon switch in.",
+		shortDesc: "+2 Def and SpD on switch in.",
+		name: "Guardian Armor",
+		onStart(pokemon) {
+			this.boost({def: 2, spd: 2}, pokemon);
+		},
+	},
+
 	// Darth
 	guardianangel: {
 		desc: "This Pokemon restores 1/3 of its maximum HP, rounded down, when it switches out. When switching in, this Pokemon's types are changed to resist the weakness of the last and stats Pokemon in before it.",

--- a/data/mods/ssb/conditions.ts
+++ b/data/mods/ssb/conditions.ts
@@ -295,6 +295,18 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 			}
 		},
 	},
+	celine: {
+		noCopy: true,
+		onStart() {
+			this.add(`c|${getName('Celine')}|Support has arrived!`);
+		},
+		onSwitchOut() {
+			this.add(`c|${getName('Celine')}|Brb writing`);
+		},
+		onFaint() {
+			this.add(`c|${getName('Celine')}|'Tis only a flesh wound!`); // escape the quote?
+		},
+	},
 	chloe: {
 		noCopy: true,
 		onStart() {

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -693,9 +693,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		onTryHit(pokemon) {
 			return !!this.queue.willAct() && this.runEvent('StallMove', pokemon);
 		},
-		onHit(pokemon) {
-			pokemon.addVolatile('stall');
-		},
 		condition: {
 			duration: 1,
 			onStart(target) {
@@ -723,14 +720,14 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				}
 				if (move.category === 'Physical') {
 					const statuses = ['brn', 'par', 'tox'];
-					source.trySetStatus(this.sample(statuses),target)
+					source.trySetStatus(this.sample(statuses),target);
 				}
 				return this.NOT_FAIL;
-			},
+			}, 
 			onHit(target, source, move) {
 				if (move.category === 'Physical') {
 					const statuses = ['brn', 'par', 'tox'];
-					source.trySetStatus(this.sample(statuses),target)
+					source.trySetStatus(this.sample(statuses),target);
 				}
 			},
 		},

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -720,15 +720,15 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				}
 				if (move.category === 'Physical') {
 					const statuses = ['brn', 'par', 'tox'];
-					source.trySetStatus(this.sample(statuses),target);
+					source.trySetStatus(this.sample(statuses), target);
 					source.forceSwitchFlag = true;
 				}
 				return this.NOT_FAIL;
-			}, 
+			},
 			onHit(target, source, move) {
 				if (move.category === 'Physical') {
 					const statuses = ['brn', 'par', 'tox'];
-					source.trySetStatus(this.sample(statuses),target);
+					source.trySetStatus(this.sample(statuses), target);
 					source.forceSwitchFlag = true;
 				}
 			},

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -721,6 +721,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				if (move.category === 'Physical') {
 					const statuses = ['brn', 'par', 'tox'];
 					source.trySetStatus(this.sample(statuses),target);
+					source.forceSwitchFlag = true;
 				}
 				return this.NOT_FAIL;
 			}, 
@@ -728,6 +729,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				if (move.category === 'Physical') {
 					const statuses = ['brn', 'par', 'tox'];
 					source.trySetStatus(this.sample(statuses),target);
+					source.forceSwitchFlag = true;
 				}
 			},
 		},

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -734,7 +734,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				}
 			},
 		},
-		forceSwitch: true,
 		secondary: null,
 		target: "self",
 		type: "Normal",

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -667,6 +667,79 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		type: "Fire",
 	},
 
+	// Celine
+	statusguard: {
+		accuracy: 100,
+		basePower: 0,
+		category: "Status",
+		desc: "Protects from physical moves. If hit by physical move, opponent is either badly poisoned, burned, or paralyzed at random and is forced out. Special attacks and status moves go through this protect.",
+		shortDesc: "Protected from physical attacks. Contact: burn, par, or tox.",
+		name: "Status Guard",
+		pp: 10,
+		priority: 4,
+		flags: {protect: 1},
+		stallingMove: true,
+		volatileStatus: 'statusguard',
+		onTryMovePriority: 100,
+		onTryMove() {
+			this.attrLastMove('[still]');
+		},
+		onHit(pokemon) {
+			pokemon.addVolatile('stall');
+		},
+		onPrepareHit(target, source) {
+			this.add('-anim', source, 'Protect', source);
+		},
+		onTryHit(pokemon) {
+			return !!this.queue.willAct() && this.runEvent('StallMove', pokemon);
+		},
+		onHit(pokemon) {
+			pokemon.addVolatile('stall');
+		},
+		condition: {
+			duration: 1,
+			onStart(target) {
+				this.add('-singleturn', target, 'move: Protect');
+			},
+			onTryHitPriority: 3,
+			onTryHit(target, source, move) {
+				if (!move.flags['protect']) {
+					if (move.isZ || (move.isMax && !move.breaksProtect)) target.getMoveHitData(move).zBrokeProtect = true;
+					return;
+				}
+				if (move.category === 'Special' || move.category === 'Status') {
+					return;
+				} else if (move.smartTarget) {
+					move.smartTarget = false;
+				} else {
+					this.add('-activate', target, 'move: Protect');
+				}
+				const lockedmove = source.getVolatile('lockedmove');
+				if (lockedmove) {
+					// Outrage counter is reset
+					if (source.volatiles['lockedmove'].duration === 2) {
+						delete source.volatiles['lockedmove'];
+					}
+				}
+				if (move.category === 'Physical') {
+					const statuses = ['brn', 'par', 'tox'];
+					source.trySetStatus(this.sample(statuses),target)
+				}
+				return this.NOT_FAIL;
+			},
+			onHit(target, source, move) {
+				if (move.category === 'Physical') {
+					const statuses = ['brn', 'par', 'tox'];
+					source.trySetStatus(this.sample(statuses),target)
+				}
+			},
+		},
+		forceSwitch: true,
+		secondary: null,
+		target: "self",
+		type: "Normal",
+	},
+
 	// Chloe
 	vsni: {
 		accuracy: 55,

--- a/data/mods/ssb/random-teams.ts
+++ b/data/mods/ssb/random-teams.ts
@@ -137,6 +137,12 @@ export const ssbSets: SSBSets = {
 		signatureMove: 'Never Lucky',
 		evs: {hp: 248, def: 36, spe: 224}, ivs: {atk: 0}, nature: 'Timid',
 	},
+	Celine: {
+		species: 'Lucario', ability: 'Guardian Armor', item: 'Leftovers', gender: 'F',
+		moves: ['Wish', 'Teleport', 'Drain Punch'],
+		signatureMove: 'Status Guard',
+		evs: {hp: 248, def: 252, spd: 8}, nature: 'Impish',
+	},
 	Chloe: {
 		species: 'Delphox', ability: 'No Guard', item: 'Heavy-Duty Boots', gender: 'F',
 		moves: ['Nasty Plot', 'Inferno', 'Psystrike'],


### PR DESCRIPTION
1. Celine's ability now boosts just like Dauntless Shield on switch-in
2. Custom move "Status Guard" modeled after King's Shield. Protects from physical attacks and sets status as expected. However setting forceSwitch: true always phazes Celine and not the opponent, is this because it's a protect move?