### PR TITLE
Don't regenerate items on forme change

### DIFF
--- a/data/mods/ssb/abilities.ts
+++ b/data/mods/ssb/abilities.ts
@@ -37,7 +37,7 @@ export function changeSet(context: Battle, pokemon: Pokemon, newSet: SSBSet, cha
 	pokemon.maxhp = newMaxHP;
 	let item = newSet.item;
 	if (typeof item !== 'string') item = item[Math.floor(Math.random() * item.length)];
-	pokemon.setItem(item);
+	if (context.toID(item) !== pokemon.item) pokemon.setItem(item);
 	const newMoves = changeMoves(context, pokemon, newSet.moves.concat(newSet.signatureMove));
 	pokemon.moveSlots = newMoves;
 	// @ts-ignore Necessary so Robb576 doesn't get 8 moves

--- a/data/mods/ssb/abilities.ts
+++ b/data/mods/ssb/abilities.ts
@@ -37,7 +37,7 @@ export function changeSet(context: Battle, pokemon: Pokemon, newSet: SSBSet, cha
 	pokemon.maxhp = newMaxHP;
 	let item = newSet.item;
 	if (typeof item !== 'string') item = item[Math.floor(Math.random() * item.length)];
-	if (context.toID(item) !== pokemon.item) pokemon.setItem(item);
+	if (context.toID(item) !== (pokemon.item || pokemon.lastItem)) pokemon.setItem(item);
 	const newMoves = changeMoves(context, pokemon, newSet.moves.concat(newSet.signatureMove));
 	pokemon.moveSlots = newMoves;
 	// @ts-ignore Necessary so Robb576 doesn't get 8 moves


### PR DESCRIPTION
[13:20] Tyrant: @Annika I think we shouldn’t modify item for ssb sets who change form but don’t change item (specifically: Yuki, Jho, etc)